### PR TITLE
Update title on new windows

### DIFF
--- a/uct-background.js
+++ b/uct-background.js
@@ -59,6 +59,10 @@ async function main() {
 
     // Trigger on registered hotkeys
     browser.commands.onCommand.addListener(userToggle);
+
+    // Initialize new windows
+    browser.windows.onCreated.addListener((window) => updateTitlePrefixes(window));
+
     console.log('Init complete');
 }
 
@@ -134,9 +138,10 @@ async function toggleTitlePrefix(windowId, titlePrefix) {
 }
 
 // Update prefix for specified window
-async function updateTitlePrefixes() {
-    // Only change current window
-    const windowId = await browser.windows.getCurrent();
+async function updateTitlePrefixes(windowId) {
+    // Default to current window
+    windowId ??= await browser.windows.getCurrent();
+
     const settings = await browser.storage.local.get(['toggles', 'general']);
     const toggles = settings.toggles;
     let titlePrefix = '';


### PR DESCRIPTION
Currently the extension does not update the title on new windows after initialization completed, leading to a weird behavior - the toggles are not applied until one got changed. That means when you open a new window, you'd have to toggle off then on again for the original setting to remain.

This PR fixes it by calling `updateTitlePrefixes` on every window opened so settings will be applied.